### PR TITLE
fix: ConfirmationCodeUserException

### DIFF
--- a/src/Exception/ConfirmationCodeUserException.php
+++ b/src/Exception/ConfirmationCodeUserException.php
@@ -23,6 +23,10 @@ class ConfirmationCodeUserException extends \Exception
 
     public static function doNotExistOrInvalid(?\Exception $exception = null): \Exception
     {
-        return new static('Confirmation request impossible due to invalid or not existing code.', $exception?->getCode(), $exception);
+        return new static(
+            'Confirmation request impossible due to invalid or not existing code.',
+            $exception?->getCode() ?? 0,
+            $exception
+        );
     }
 }


### PR DESCRIPTION
fix: Deprecated: Exception::__construct(): Passing null to parameter #2 ($code) of type int is deprecated